### PR TITLE
Added error handling logic for ERROR frames - Dogan

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,6 +29,7 @@ function StompClient(address, port, user, pass, protocolVersion) {
   //TODO Check what the default stomp port is
   this.port = (port || 2098);
   this.version = (protocolVersion || '1.0');
+  this.errorCallbacks = [];
   this.subscriptions = {};
   this._stompFrameEmitter = new StompFrameEmitter(StompFrameCommands[this.version]);
   return this;
@@ -36,8 +37,13 @@ function StompClient(address, port, user, pass, protocolVersion) {
 
 util.inherits(StompClient, events.EventEmitter);
 
-StompClient.prototype.connect = function(connectedCallback) {
+StompClient.prototype.connect = function (connectedCallback, errorCallback) {
   var self = this;
+
+  if (Object.prototype.toString.call(errorCallback) === '[object Function]') {
+    this.errorCallbacks.push(errorCallback);
+  }
+
   self.stream = net.createConnection(self.port, self.address);
   self.stream.on('connect', function() {
     self.onConnect();
@@ -48,11 +54,21 @@ StompClient.prototype.connect = function(connectedCallback) {
   });
 };
 
-StompClient.prototype.disconnect = function(disconnectedCallback) {
-  var self = this;
+StompClient.prototype.disconnect = function (disconnectedCallback, errorCallbackToRemove) {
+  var self = this,
+      errorCallbackIndex;
+
   if (this.stream) {
 
-    this.on('disconnect', disconnectedCallback);
+    this.on('disconnect', function () {
+
+      if (errorCallbackToRemove) {
+        errorCallbackIndex = this.errorCallbacks.indexOf(errorCallbackToRemove);
+        this.errorCallbacks.splice(errorCallbackIndex, 1);
+      }
+
+      disconnectedCallback();
+    });
 
     var frame = new StompFrame({
       command: 'DISCONNECT'
@@ -95,8 +111,10 @@ StompClient.prototype.onConnect = function() {
   });
 
   frameEmitter.on('ERROR', function(frame) {
-    //TODO error handling...???
     util.log(frame.headers.message + ' (frame body: ' + frame.body + ')');
+    for (var i = 0; i < self.errorCallbacks.length; i++) {
+      self.errorCallbacks[i](frame.headers, frame.body);
+    }
   });
 
   frameEmitter.on('parseError', function(err) {
@@ -129,14 +147,14 @@ StompClient.prototype.subscribe = function(queue, callback, headers) {
   this.subscriptions[queue].push(callback);
 };
 
-StompClient.prototype.unsubscribe = function(queue, headers, callback) {
+// no need to pass a callback parameter as there is no acknowledgment for successful UNSUBSCRIBE from the STOMP server
+StompClient.prototype.unsubscribe = function (queue, headers) {
   headers && (headers["destination"] = queue) || (headers = {"destination": queue});
   new StompFrame({
     command: 'UNSUBSCRIBE',
     headers: headers
   }).send(this.stream);
   delete this.subscriptions[queue];
-  callback();
 };
 
 StompClient.prototype.publish = function(queue, message) {


### PR DESCRIPTION
Hello coders,

For your kind review and pull.

Commit message:

"Added logic to register error callbacks on connect() and de-register on disconnect(). All registered error callbacks get called on reception of ERROR frames. Also removed unnecessary callback in subscribe() method signature."

Cheers

Dogan
