### PR TITLE
Custom header feature added to `publish` method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -157,12 +157,11 @@ StompClient.prototype.unsubscribe = function (queue, headers) {
   delete this.subscriptions[queue];
 };
 
-StompClient.prototype.publish = function(queue, message) {
+StompClient.prototype.publish = function(queue, message, headers) {
+  headers && (headers["destination"] = queue) || (headers = {"destination": queue});
   new StompFrame({
     command: 'SEND',
-    headers: {
-      destination: queue
-    },
+    headers: headers,
     body: message
   }).send(this.stream);
 };


### PR DESCRIPTION
Hi!
This changes done for compatibility with custom headers for `publish` method.
BTW, header `transformation` used in `stompjms-client-1.13` for java. It's non standart header.

---

Oleg
