### PR TITLE
Update node dependency with no arbitrary cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main" : "lib/client.js",
   "engines": {
-    "node":">= 0.4 < 0.8"
+    "node":">= 0.4"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
If you prefer, you can explicitly list 0.11, but it makes more sense to me to remove the cap, then have to update stomp-client every time there is a new node release.
