### PR TITLE
Set default STOMP port to the common value

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following enhancements have been added:
 	var Client = require('stomp-client').StompClient;
 	var destination = '/queue/someQueueName';
 
-	var client = new Client('127.0.0.1', 2098, 'user', 'pass', '1.0');
+	var client = new Client('127.0.0.1', 61613, 'user', 'pass', '1.0');
 
 	client.connect(function(sessionId) {
 		client.subscribe(destination, function(body, headers) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -26,8 +26,7 @@ function StompClient(address, port, user, pass, protocolVersion) {
   this.user = (user || '');
   this.pass = (pass || '');
   this.address = (address || '127.0.0.1');
-  //TODO Check what the default stomp port is
-  this.port = (port || 2098);
+  this.port = (port || 61613);
   this.version = (protocolVersion || '1.0');
   this.errorCallbacks = [];
   this.subscriptions = {};

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -55,7 +55,7 @@ module.exports = testCase({
     test.equal(stompClient.user, '');
     test.equal(stompClient.pass, '');
     test.equal(stompClient.address, '127.0.0.1');
-    test.equal(stompClient.port, 2098);
+    test.equal(stompClient.port, 61613);
     test.equal(stompClient.version, '1.0');
 
     test.done();


### PR DESCRIPTION
Both RabbitMQ and ActiveMQ use 61613.
