### PR TITLE
Fix connect test, which was passing an options object

### DIFF
--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -11,7 +11,7 @@ util.log = function() {};
 module.exports = testCase({
 
   'check connect to closed port errors': function(test) {
-    var stompClient = new StompClient({port: 4});
+    var stompClient = new StompClient('127.0.0.1', 4);
 
     stompClient.connect(function() {});
 


### PR DESCRIPTION
An options object isn't supported, it was being used as an address, and
passed as a final argument to createConnection(port,...), where it was
ignored because it is not a function. This becomes noticeable once the
default port becomes correct, and you are running a STOMP server,
because this test ends up using a valid default port.
