### PR TITLE
An attempt to better support ActiveMQ by suppressing content-length header for text messages.  Inclusion of the content-length ...

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -23,9 +23,13 @@ StompFrame.prototype.send = function(stream) {
   for (var key in this.headers) {
     frame += key + ':' + this.headers[key] + '\n';
   }
+
   if (this.body.length > 0) {
-    frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    if(!this.headers.hasOwnProperty('suppress-content-length')) {
+      frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    }
   }
+
   frame += '\n';
   if (this.body.length > 0) {
     frame += this.body;


### PR DESCRIPTION
...header, although correct by Stomp protocol standards, is actually a flag for ActiveMQ to consider whether the message is a JMSTextMessage, or JMSBytesMessage.

For clarification, see under "Working with JMS Text/Bytes Messages and Stomp":
http://activemq.apache.org/stomp.html
This proposes the inclusion of a 'suppress-content-length' header than can be passed in when creating the stomp client.
Doing so allows us to send TextMessages rather than BytesMessages to ActiveMQ.

Although this is an ActiveMQ deficiency, seems like Ruby Stomp Clients have been using a similar "hack" for a while.
