### PR TITLE
Fix issue #29: Parsing of header values that include embedded colons (':').

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -88,15 +88,15 @@ StompFrameEmitter.prototype.parseHeaders = function () {
       this.incrementState();
       break;
     } else {
-      var kv = line.split(':', 2);
-      if (kv.length != 2) {
+      var kv = line.split(':');
+      if (kv.length < 2) {
         this.error({
           message: 'Error parsing header',
           details: 'No ":" in line "' + line + '"'
         });
         break;
       }
-      this.frame.setHeader(kv[0], kv[1]);
+      this.frame.setHeader(kv[0], kv.slice(1).join(':'));
     }
   }
 };

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -222,7 +222,7 @@ module.exports = testCase({
     var self = this;
     var testId = '1234';
     var destination = '/queue/someQueue';
-    var messageId = 1;
+    var messageId = 'ID:SomeID:1';
     var messageToBeSent = 'oh herrow!';
 
     test.expect(5);


### PR DESCRIPTION
When using ActiveMQ with temporary queue in reply-to header, the resulting value includes ':' characters, which was causing the parser to only use the first part of value up to the first ':' as the header value.