### PR TITLE
It appears that travis is failing the build on old versions of node.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
-  - 0.4
-  - 0.6
-  - 0.8
   - 0.10

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main" : "lib/client.js",
   "engines": {
-    "node":">= 0.4"
+    "node":">= 0.10"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
We're just going to support version 0.10 going forwards.

Testing of older versions will have to be at the users risk.