### PR TITLE
Add TLS support for secure connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Require returns a constructor for STOMP client instances.
 For backwards compatibility, `require('stomp-client').StompClient` is also
 supported.
 
-## Stomp(address, [port], [user], [pass], [protocolVersion], [vhost], [reconnectOpts])
+## Stomp(address, [port], [user], [pass], [protocolVersion], [vhost], [reconnectOpts], [tls])
 
 - `address`: address to connect to, default is `"127.0.0.1"`
 - `port`: port to connect to, default is `61613`
@@ -67,6 +67,7 @@ supported.
 - `protocolVersion`: see below, defaults to `"1.0"`
 - `vhost`: see below, defaults to `null`
 - `reconnectOpts`: see below, defaults to `{}`
+- `tls`: Establish a tls/ssl connection.  If an object is passed for this argument it will passed as options to the tls module.
 
 Protocol version negotiation is not currently supported and version `"1.0"` is
 the only supported version.
@@ -75,6 +76,10 @@ ReconnectOpts should contain an integer `retries` specifying the maximum number
 of reconnection attempts, and a `delay` which specifies the reconnection delay.
  (reconnection timings are calculated using exponential backoff. The first reconnection
  happens immediately, the second reconnection happens at `+delay` ms, the third at `+ 2*delay` ms, etc).
+
+## Stomp(options)
+
+- `options`: Properties are named the same as the positional parameters above. The property 'host' is accepted as an alias for 'address'.
 
 ## stomp.connect([callback, [errorCallback]])
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var net = require('net');
+var tls = require('tls');
 var util = require('util');
 var events = require('events');
 var StompFrame = require('./frame').StompFrame;
@@ -49,7 +50,38 @@ var StompFrameCommands = {
   }
 };
 
-function StompClient(address, port, user, pass, protocolVersion, vhost, reconnectOpts) {
+function StompClient(opts) {
+
+  var address, port, user, pass, protocolVersion, vhost, reconnectOpts, tlsOpts;
+
+  if(arguments.length !== 1 || typeof opts === 'string') {
+    address = opts;
+    port = arguments[1];
+    user = arguments[2];
+    pass = arguments[3];
+    protocolVersion = arguments[4];
+    vhost = arguments[5];
+    reconnectOpts = arguments[6];
+    tlsOpts = arguments[7];
+    if(tlsOpts === true) {
+      tlsOpts = {};
+    }
+  }
+  else {
+    address = opts.address || opts.host;
+    port = opts.port;
+    user = opts.user;
+    pass = opts.pass;
+    protocolVersion = opts.protocolVersion;
+    vhost = opts.vhost;
+    reconnectOpts = opts.reconnectOpts;
+    tlsOpts = opts.tls;
+    // If boolean then TLS options are mixed in with other options
+    if(tlsOpts === true) {
+      tlsOpts = opts;
+    }
+  }
+
   events.EventEmitter.call(this);
   this.user = (user || '');
   this.pass = (pass || '');
@@ -61,6 +93,7 @@ function StompClient(address, port, user, pass, protocolVersion, vhost, reconnec
   this._stompFrameEmitter = new StompFrameEmitter(StompFrameCommands[this.version]);
   this.vhost = vhost || null;
   this.reconnectOpts = reconnectOpts || {};
+  this.tls = tlsOpts;
   this._retryNumber = 0;
   this._retryDelay = this.reconnectOpts.delay;
   return this;
@@ -78,8 +111,18 @@ StompClient.prototype.connect = function (connectedCallback, errorCallback) {
     self.on('error', errorCallback);
   }
 
-  self.stream = net.createConnection(self.port, self.address);
-  self.stream.on('connect', self.onConnect.bind(this));
+  var connectEvent;
+
+  if(this.tls) {
+    self.stream = tls.connect(self.port, self.address, this.tls);
+    connectEvent = 'secureConnect';
+  }
+  else {
+    self.stream = net.createConnection(self.port, self.address);
+    connectEvent = 'connect';
+  }
+
+  self.stream.on(connectEvent, self.onConnect.bind(this));
 
   self.stream.on('error', function(err) {
     process.nextTick(function() {
@@ -104,8 +147,9 @@ StompClient.prototype.connect = function (connectedCallback, errorCallback) {
   });
 
   if (connectedCallback) {
-    self.on('connect', connectedCallback);
+    self.on(connectEvent, connectedCallback);
   }
+
   return this;
 };
 
@@ -300,26 +344,8 @@ Object.defineProperty(StompClient.prototype, 'writable', {
   }
 });
 
-function SecureStompClient(address, port, user, pass, credentials) {
-  events.EventEmitter.call(this);
-  var self = this;
-  self.user = user;
-  self.pass = pass;
-  self.subscriptions = {};
-  self.stream = net.createConnection(port, address);
-  self.stream.on('connect', function() {
-    self.stream.setSecure(credentials);
-  });
-  self.stream.on('secure', function() {
-    self.onConnect();
-  });
-}
-
-util.inherits(SecureStompClient, StompClient);
-
 module.exports = StompClient;
 module.exports.StompClient = StompClient;
-module.exports.SecureStompClient = SecureStompClient;
 
 module.exports.Errors = {
   streamNotWritable: 15201

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -72,6 +72,83 @@ module.exports = testCase({
     test.done();
   },
 
+  'check StompClient construction from paremeters': function(test) {
+    var stompClient = new StompClient(
+      'test.host.net',1234,'uname','pw', '1.1', 'q1.host.net', 
+      { retries: 10, delay: 1000 });
+
+    test.equal(stompClient.user, 'uname');
+    test.equal(stompClient.pass, 'pw');
+    test.equal(stompClient.address, 'test.host.net');
+    test.equal(stompClient.port, 1234);
+    test.equal(stompClient.version, '1.1');
+    test.equal(stompClient.vhost, 'q1.host.net');
+    test.equal(stompClient.reconnectOpts.retries, 10);
+    test.equal(stompClient.reconnectOpts.delay, 1000);
+
+    test.done();
+  },
+
+  'check StompClient construction from options': function(test) {
+    var stompClient = new StompClient( {
+      address: 'test.host.net',
+      port: 1234,
+      user: 'uname',
+      pass: 'pw', 
+      protocolVersion: '1.1', 
+      vhost: 'q1.host.net', 
+      reconnectOpts: { retries: 10, delay: 1000 }});
+
+    test.equal(stompClient.user, 'uname');
+    test.equal(stompClient.pass, 'pw');
+    test.equal(stompClient.address, 'test.host.net');
+    test.equal(stompClient.port, 1234);
+    test.equal(stompClient.version, '1.1');
+    test.equal(stompClient.vhost, 'q1.host.net');
+    test.equal(stompClient.reconnectOpts.retries, 10);
+    test.equal(stompClient.reconnectOpts.delay, 1000);
+
+    test.done();
+  },
+
+  'check StompClient TLS construction': function(test) {
+
+    var stompClient = new StompClient(
+      'test.host.net',1234,'uname','pw', null, null, null, true);
+    test.deepEqual(stompClient.tls, {}, 'TLS not set by parameter');
+
+    var stompClient = new StompClient(
+      'test.host.net',1234,'uname','pw', null, null, null, false);
+    test.ok(!stompClient.tls, 'TLS incorrectly set by parameter');
+
+    var stompClient = new StompClient({ 
+      host: 'secure.host.net',  
+      tls: true,
+      cert: 'dummy'
+      });
+    test.equal(stompClient.address, 'secure.host.net');
+    test.deepEqual(stompClient.tls.cert, 'dummy', 'TLS not set by option');
+
+    var stompClient = new StompClient({ 
+      host: 'secure.host.net',  
+      tls: false,
+      cert: 'dummy'
+      });
+    test.equal(stompClient.address, 'secure.host.net');
+    test.ok(!stompClient.tls, 'TLS incorrectly set by option');
+
+    var stompClient = new StompClient({ 
+      host: 'secure.host.net',  
+      tls: {
+        cert: 'dummy'
+      }});
+    test.equal(stompClient.address, 'secure.host.net');
+    test.deepEqual(stompClient.tls.cert, 'dummy', 
+      'TLS not set by nested option');
+
+    test.done();
+  },
+
   'check outbound CONNECT frame correctly follows protocol specification': function(test) {
     var self = this;
     test.expect(4);


### PR DESCRIPTION
tls parameter added to constructor, can be boolean or options to tls
module.

Constructor overloaded to accept options object in addition to positional
parameters.

Removed SecureStompClient as it relied on obsolete stream.setSecure
method.