### PR TITLE
emit 'message' event on message

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ the new `sessionId` and the reconnection attempt number.
 Emitted when the client has been disconnected for whatever reason, but is going
 to attempt to reconnect.
 
+## Event: `'message'` (body, headers)
+
+Emitted for each message received. This can be used as a simple way to receive
+messages for wildcard destination subscriptions that would otherwise not trigger
+the subscription callback.
+
 ## LICENSE
 
 [MIT](LICENSE)

--- a/lib/client.js
+++ b/lib/client.js
@@ -206,6 +206,7 @@ StompClient.prototype.onConnect = function() {
         callback(frame.body, frame.headers);
       });
     }
+    self.emit('message', frame.body, frame.headers);
   });
 
   frameEmitter.on('CONNECTED', function(frame) {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "nodeunit": "0.7.4",
-    "jshint": "2.4.3"
+    "nodeunit": "0.9.1",
+    "jshint": "2.8.0"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
I know you have wildcards on the [TODO](https://github.com/easternbloc/node-stomp-client/blob/master/TODO.md) list however all I need is a simple catch-all subscription which can be achieved just by emitting a 'message' event on each message.

Also notice that wildcard subscriptions come in different flavours - Apollo uses `**` for nested wildcard matching, whereas ActiveMQ uses `>` - I'm not sure it would be such a good idea to try and reimplement the wildcard logic yourself for this reason.

If you're happy with the idea, I can add some tests and docs too.