### PR TITLE
Fix to call connect callback when connection complete on TLS connection.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -147,7 +147,7 @@ StompClient.prototype.connect = function (connectedCallback, errorCallback) {
   });
 
   if (connectedCallback) {
-    self.on(connectEvent, connectedCallback);
+    self.on('connect', connectedCallback);
   }
 
   return this;


### PR DESCRIPTION
Module was not calling connect callback function on connection complete due to registering on wrong event name.

Issue [#51](https://github.com/easternbloc/node-stomp-client/issues/51)