### PR TITLE
Adding parameter in publish method to choose message type.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -304,14 +304,14 @@ StompClient.prototype.unsubscribe = function (queue, headers) {
   return this;
 };
 
-StompClient.prototype.publish = function(queue, message, headers) {
+StompClient.prototype.publish = function(queue, message, headers, type) {
   headers = _extend({}, headers);
   headers.destination = queue;
   new StompFrame({
     command: 'SEND',
     headers: headers,
     body: message
-  }).send(this.stream);
+  }).send(this.stream, type);
   return this;
 };
 

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -16,14 +16,14 @@ StompFrame.prototype.toString = function() {
   });
 };
 
-StompFrame.prototype.send = function(stream) {
+StompFrame.prototype.send = function(stream, type) {
   // Avoid small writes, they get sent in their own tcp packet, which
   // is not efficient (and v8 does fast string concat).
   var frame = this.command + '\n';
   for (var key in this.headers) {
     frame += key + ':' + this.headers[key] + '\n';
   }
-  if (this.body.length > 0) {
+  if(type && type === "byte" && this.body.length > 0) {
     frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
   }
   frame += '\n';

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -23,7 +23,7 @@ StompFrame.prototype.send = function(stream, type) {
   for (var key in this.headers) {
     frame += key + ':' + this.headers[key] + '\n';
   }
-  if(type && type === "byte" && this.body.length > 0) {
+  if((!type || type === "byte") && this.body.length > 0) {
     frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
   }
   frame += '\n';

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -82,6 +82,31 @@ module.exports = testCase({
     test.deepEqual(expectedStream.join(''), connectionObserver.writeBuffer.join(''), 'frame stream data is correctly output on the mocked wire');
     test.done();
   },
+  
+  'test stream writes are correct and content-length is not set for text messages': function (test) {
+    var frame = new StompFrame({
+      'command': 'HITME',
+      'headers': {
+        'header1': 'value1',
+        'header2': 'value2'
+      },
+      'body': 'wewp de doo'
+    });
+
+    var expectedStream = [
+      'HITME\n',
+      'header1:value1\n',
+      'header2:value2\n',
+      '\n',
+      'wewp de doo',
+      '\u0000'
+    ];
+
+    frame.send(connectionObserver, "text");
+
+    test.deepEqual(expectedStream.join(''), connectionObserver.writeBuffer.join(''), 'frame stream data is correctly output on the mocked wire and the content-length header is not set.');
+    test.done();
+  },
 
   'check validation of arbitrary frame with arbitrary frame construct': function (test) {
     var validation,


### PR DESCRIPTION
The new fourth parameter of the "publish" method can be informed with value "byte" if you need to publish a ByteMessage.