### PR TITLE
add accept-version header to CONNET frame

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -243,6 +243,10 @@ StompClient.prototype.onConnect = function() {
     'passcode': self.pass
   };
 
+  if (this.version !== '1.0') {
+    headers['accept-version'] = '1.0,1.1';
+  }
+
   if(this.vhost && this.version === '1.1')
     headers.host = this.vhost;
 


### PR DESCRIPTION
From the STOMP 1.1 specs:

> From STOMP 1.1 and onwards, the CONNECT frame **MUST** include the accept-version header. It SHOULD be set to a comma separated list of incrementing STOMP protocol versions that the client supports. **If the accept-version header is missing, it means that the client only supports version 1.0 of the protocol.**
> 
> The protocol that will be used for the rest of the session will be the highest protocol version that both the client and server have in common.

This PR allows using version 1.1 and thus ACK/NACK.

However, this does **not** introduce protocol negotiation and will likely cause issues in case the server does not support protocol version 1.1.

Also, please be aware that extra headers required by 1.1 (such as the SUBSCRIBE `id`) still need to be added manually, e.g:

``` js
var Stomp = require("stomp-client");

var stomp_client = new Stomp({
  // ...
  protocolVersion: "1.1"
});

var sub_id = "foobar";
var headers = {
  ack: "client-individual",
  id: sub_id,
};

stomp_client.subscribe("/queue/example", headers, function(body, headers) {
  var message_id = headers["message-id"];

  if (success(body)) {
    stomp_client.ack(message_id, sub_id);
  } else {
    stomp_client.nack(message_id, sub_id);
  }
};
```
