### PR TITLE
Suppress content-length header for text messages to be compatible with JMX clients

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -24,7 +24,10 @@ StompFrame.prototype.send = function(stream) {
     frame += key + ':' + this.headers[key] + '\n';
   }
   if (this.body.length > 0) {
-    frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    //suppress content-length header for text messages. Use Buffer for byte messages
+    if (typeof(this.body) === 'string') {
+      frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    }
   }
   frame += '\n';
   if (this.body.length > 0) {

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -25,7 +25,7 @@ StompFrame.prototype.send = function(stream) {
   }
   if (this.body.length > 0) {
     //suppress content-length header for text messages. Use Buffer for byte messages
-    if (typeof(this.body) === 'string') {
+    if (typeof(this.body) !== 'string') {
       frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
     }
   }


### PR DESCRIPTION
Suppress content-length header for text messages to be compatible with JMX clients. Use Buffer for byte messages.
