### PR TITLE
Adds support for 'suppress-content-length' header

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -24,7 +24,9 @@ StompFrame.prototype.send = function(stream) {
     frame += key + ':' + this.headers[key] + '\n';
   }
   if (this.body.length > 0) {
-    frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    if (!this.headers.hasOwnProperty('suppress-content-length')) {
+      frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    }
   }
   frame += '\n';
   if (this.body.length > 0) {

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -149,7 +149,7 @@ module.exports = testCase({
     //Check the headers for the content-length header
     var writtenString = connectionObserver.writeBuffer.join('');
     var containsContentLengthHeader = (writtenString.split("\n").indexOf("content-length:20") == -1 ? false : true);
-    test.equal(containsContentLengthHeader, containsContentLengthHeader, "Content length header should not exist since we are suppressing it");
+    test.equal(containsContentLengthHeader, false, "Content length header should not exist since we are suppressing it");
     test.done();
   },
   'test stream write correctly handles single-byte UTF-8 characters': function(test) {

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -122,6 +122,33 @@ module.exports = testCase({
 
     test.done();
   },
+  'test content-length header is not present when suppress-content-length is provided': function(test) {
+    var frame = new StompFrame({
+        'command': 'SEND',
+        'body' : 'Content length is 20'
+    });
+    frame.send(connectionObserver);
+
+    //Check the headers for the content-length header
+    var writtenString = connectionObserver.writeBuffer.join('');
+    var containsContentLengthHeader = writtenString.split("\n").indexOf("content-length:20");
+    test.equal(containsContentLengthHeader, true, "Content length header should exist since we are not suppressing it");
+
+    var frame = new StompFrame({
+        'command': 'SEND',
+        'headers': {
+          'suppress-content-length': true
+        },
+        'body' : 'Content length is 20'
+    });
+    frame.send(connectionObserver);
+
+    //Check the headers for the content-length header
+    var writtenString = connectionObserver.writeBuffer.join('');
+    var containsContentLengthHeader = writtenString.split("\n").indexOf("content-length:20");
+
+    test.done();
+  },
   'test stream write correctly handles single-byte UTF-8 characters': function(test) {
       var frame = new StompFrame({
           'command': 'SEND',

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -122,7 +122,7 @@ module.exports = testCase({
 
     test.done();
   },
-  'test content-length header is not present when suppress-content-length is provided': function(test) {
+  'test content-length header is present when suppress-content-length is not': function(test) {
     var frame = new StompFrame({
         'command': 'SEND',
         'body' : 'Content length is 20'
@@ -131,9 +131,12 @@ module.exports = testCase({
 
     //Check the headers for the content-length header
     var writtenString = connectionObserver.writeBuffer.join('');
-    var containsContentLengthHeader = writtenString.split("\n").indexOf("content-length:20");
+    var containsContentLengthHeader = (writtenString.split("\n").indexOf("content-length:20") == -1 ? false : true);
     test.equal(containsContentLengthHeader, true, "Content length header should exist since we are not suppressing it");
 
+    test.done();
+  },
+  'test content-length is not present when suppress-content-length is provided': function(test) {
     var frame = new StompFrame({
         'command': 'SEND',
         'headers': {
@@ -145,8 +148,8 @@ module.exports = testCase({
 
     //Check the headers for the content-length header
     var writtenString = connectionObserver.writeBuffer.join('');
-    var containsContentLengthHeader = writtenString.split("\n").indexOf("content-length:20");
-
+    var containsContentLengthHeader = (writtenString.split("\n").indexOf("content-length:20") == -1 ? false : true);
+    test.equal(containsContentLengthHeader, containsContentLengthHeader, "Content length header should not exist since we are suppressing it");
     test.done();
   },
   'test stream write correctly handles single-byte UTF-8 characters': function(test) {


### PR DESCRIPTION
added a check for the suppress-content-length header, which if present, does not add the content-length header. also added unit test to validate it.