### PR TITLE
add accept-version header to CONNECT frame when using version > 1.0

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -243,6 +243,10 @@ StompClient.prototype.onConnect = function() {
     'passcode': self.pass
   };
 
+  if (this.version !== '1.0') {
+    headers['accept-version'] = Object.keys(StompFrameCommands).join(',');
+  }
+
   if(this.vhost && this.version === '1.1')
     headers.host = this.vhost;
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -171,6 +171,28 @@ module.exports = testCase({
 
   },
 
+  'send accept-version header on CONNECT when using version > 1.0': function(test) {
+    var self = this;
+    test.expect(2);
+
+    sendHook = function(stompFrame) {
+      test.equal(stompFrame.command, 'CONNECT');
+      test.deepEqual(stompFrame.headers, {
+          login: 'user',
+          passcode: 'pass',
+          'accept-version': '1.0,1.1'
+      });
+
+      test.done();
+    };
+
+    //start the test
+    this.stompClient.version = '1.1';
+    this.stompClient.connect();
+    connectionObserver.emit('connect');
+
+  },
+
   'check inbound CONNECTED frame parses correctly': function(test) {
     var self = this;
     var testId = '1234';


### PR DESCRIPTION
Based on STOMP 1.1 specs (https://stomp.github.io/stomp-specification-1.1.html#Protocol_Negotiation):

> From STOMP 1.1 and onwards, the CONNECT frame MUST include the accept-version header. It SHOULD be set to a comma separated list of incrementing STOMP protocol versions that the client supports. If the accept-version header is missing, it means that the client only supports version 1.0 of the protocol.

this PR does not introduce protocol negotiation