### PR TITLE
Added reconnect listener to connect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -148,7 +148,7 @@ StompClient.prototype.connect = function (connectedCallback, errorCallback) {
 
   if (connectedCallback) {
     self.on('connect', connectedCallback);
-    if(self.listenerCount('reconnect', connectedCallback) < 1)){
+    if(self.listenerCount('reconnect', connectedCallback) < 1){
       self.on('reconnect', connectedCallback);
     }
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -148,6 +148,9 @@ StompClient.prototype.connect = function (connectedCallback, errorCallback) {
 
   if (connectedCallback) {
     self.on('connect', connectedCallback);
+    if(self.listenerCount('reconnect', connectedCallback) < 1)){
+      self.on('reconnect', connectedCallback);
+    }
   }
 
   return this;


### PR DESCRIPTION
There is a bug when we want to subscribe to rabbit while reconnecting. So I simply added one line to let the stomp remember to subscribe when reconnected.