### PR TITLE
Skip content-length header for messages with string body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.vscode

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -24,7 +24,7 @@ StompFrame.prototype.send = function(stream) {
     frame += key + ':' + this.headers[key] + '\n';
   }
   // User content-length for non-strings and if suppress-content-length header doesn't exist
-  let addContentLength = !(typeof this.body === 'string') && !this.headers.hasOwnProperty('suppress-content-length');
+  var addContentLength = !(typeof this.body === 'string') && !this.headers.hasOwnProperty('suppress-content-length');
   if (addContentLength && this.body.length > 0) {
     frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
   }

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -26,7 +26,8 @@ StompFrame.prototype.send = function(stream) {
   // User content-length for non-strings and if suppress-content-length header doesn't exist
   var addContentLength = !(typeof this.body === 'string') && !this.headers.hasOwnProperty('suppress-content-length');
   if (addContentLength && this.body.length > 0) {
-    frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
+    // this.body is Buffer or ArrayBuffer
+    frame += 'content-length:' + this.body.length + '\n';
   }
   frame += '\n';
   if (this.body.length > 0) {

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -23,10 +23,10 @@ StompFrame.prototype.send = function(stream) {
   for (var key in this.headers) {
     frame += key + ':' + this.headers[key] + '\n';
   }
-  if (this.body.length > 0) {
-    if (!this.headers.hasOwnProperty('suppress-content-length')) {
-      frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
-    }
+  // User content-length for non-strings and if suppress-content-length header doesn't exist
+  let addContentLength = !(typeof this.body === 'string') && !this.headers.hasOwnProperty('suppress-content-length');
+  if (addContentLength && this.body.length > 0) {
+    frame += 'content-length:' + Buffer.byteLength(this.body) + '\n';
   }
   frame += '\n';
   if (this.body.length > 0) {

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -11,6 +11,11 @@ connectionObserver.write = function(data) {
   this.writeBuffer.push(data);
 };
 
+// To support old and new nodejs Buffer api
+var bufferFromString = function(str) {
+  return Buffer.from ? Buffer.from(str) : new Buffer(str);
+}
+
 module.exports = testCase({
 
   setUp: function(callback) {
@@ -61,7 +66,7 @@ module.exports = testCase({
         'header1': 'value1',
         'header2': 'value2'
       },
-      'body': Buffer.from('wewp de doo')
+      'body': bufferFromString('wewp de doo')
     });
 
     // Command before headers, content-length auto-inserted, and terminating with null char (line feed chars for each line too)
@@ -125,7 +130,7 @@ module.exports = testCase({
   'test content-length header is present when suppress-content-length is not': function(test) {
     var frame = new StompFrame({
         'command': 'SEND',
-        'body' : Buffer.from('Content length is 20')
+        'body' : bufferFromString('Content length is 20')
     });
     frame.send(connectionObserver);
 
@@ -169,7 +174,7 @@ module.exports = testCase({
   'test stream write correctly handles single-byte UTF-8 characters as a buffer': function(test) {
       var frame = new StompFrame({
           'command': 'SEND',
-          'body' : Buffer.from('Welcome!')
+          'body' : bufferFromString('Welcome!')
       });
       frame.send(connectionObserver);
 
@@ -204,7 +209,7 @@ module.exports = testCase({
   'test stream write correctly handles multi-byte UTF-8 characters as a buffer': function(test) {
       var frame = new StompFrame({
           'command': 'SEND',
-          'body' : Buffer.from('Ẇḗḽḉớḿẽ☃')
+          'body' : bufferFromString('Ẇḗḽḉớḿẽ☃')
       });
       frame.send(connectionObserver);
 

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -183,7 +183,7 @@ module.exports = testCase({
       var contentLengthHeaderLine = writtenString.split("\n")[1];
       var contentLengthValue = contentLengthHeaderLine.split(":")[1].trim();
 
-      test.equal(Buffer.byteLength(frame.body), contentLengthValue, "We should be truthful about how much data we plan to send to the server");
+      test.equal(frame.body.length, contentLengthValue, "We should be truthful about how much data we plan to send to the server");
 
       test.done();
   },
@@ -218,7 +218,7 @@ module.exports = testCase({
       var contentLengthHeaderLine = writtenString.split("\n")[1];
       var contentLengthValue = contentLengthHeaderLine.split(":")[1].trim();
 
-      test.equal(Buffer.byteLength(frame.body), contentLengthValue, "We should be truthful about how much data we plan to send to the server");
+      test.equal(frame.body.length, contentLengthValue, "We should be truthful about how much data we plan to send to the server");
 
       test.done();
   },

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -61,7 +61,7 @@ module.exports = testCase({
         'header1': 'value1',
         'header2': 'value2'
       },
-      'body': 'wewp de doo'
+      'body': Buffer.from('wewp de doo')
     });
 
     // Command before headers, content-length auto-inserted, and terminating with null char (line feed chars for each line too)
@@ -125,7 +125,7 @@ module.exports = testCase({
   'test content-length header is present when suppress-content-length is not': function(test) {
     var frame = new StompFrame({
         'command': 'SEND',
-        'body' : 'Content length is 20'
+        'body' : Buffer.from('Content length is 20')
     });
     frame.send(connectionObserver);
 
@@ -152,10 +152,24 @@ module.exports = testCase({
     test.equal(containsContentLengthHeader, false, "Content length header should not exist since we are suppressing it");
     test.done();
   },
-  'test stream write correctly handles single-byte UTF-8 characters': function(test) {
+  'test content-length is not present when frame.body is string': function(test) {
+    var frame = new StompFrame({
+        'command': 'SEND',
+        'headers': {},
+        'body' : 'Content length is 20'
+    });
+    frame.send(connectionObserver);
+
+    //Check the headers for the content-length header
+    var writtenString = connectionObserver.writeBuffer.join('');
+    var containsContentLengthHeader = (writtenString.split("\n").indexOf("content-length:20") == -1 ? false : true);
+    test.equal(containsContentLengthHeader, false, "Content length header should not exist since we are suppressing it");
+    test.done();
+  },
+  'test stream write correctly handles single-byte UTF-8 characters as a buffer': function(test) {
       var frame = new StompFrame({
           'command': 'SEND',
-          'body' : 'Welcome!'
+          'body' : Buffer.from('Welcome!')
       });
       frame.send(connectionObserver);
 
@@ -168,10 +182,29 @@ module.exports = testCase({
 
       test.done();
   },
-  'test stream write correctly handles multi-byte UTF-8 characters': function(test) {
+  'test stream write correctly handles single-byte UTF-8 characters as a string': function(test) {
       var frame = new StompFrame({
           'command': 'SEND',
-          'body' : 'Ẇḗḽḉớḿẽ☃'
+          'body' : 'Welcome!'
+      });
+      frame.send(connectionObserver);
+
+      var expectedStream = [
+        'SEND\n\n',
+        'Welcome!',
+        '\0'
+      ];
+
+      var writtenString = connectionObserver.writeBuffer.join('');
+      
+      test.equal(expectedStream.join(''), writtenString, 'Sent content should be eqaul to expected content');
+
+      test.done();
+  },
+  'test stream write correctly handles multi-byte UTF-8 characters as a buffer': function(test) {
+      var frame = new StompFrame({
+          'command': 'SEND',
+          'body' : Buffer.from('Ẇḗḽḉớḿẽ☃')
       });
       frame.send(connectionObserver);
 
@@ -181,6 +214,25 @@ module.exports = testCase({
       var contentLengthValue = contentLengthHeaderLine.split(":")[1].trim();
 
       test.equal(Buffer.byteLength(frame.body), contentLengthValue, "We should be truthful about how much data we plan to send to the server");
+
+      test.done();
+  },
+  'test stream write correctly handles multi-byte UTF-8 characters as a string': function(test) {
+      var frame = new StompFrame({
+          'command': 'SEND',
+          'body' : 'Ẇḗḽḉớḿẽ☃'
+      });
+      frame.send(connectionObserver);
+
+      var expectedStream = [
+        'SEND\n\n',
+        'Ẇḗḽḉớḿẽ☃',
+        '\0'
+      ];
+
+      var writtenString = connectionObserver.writeBuffer.join('');
+      
+      test.equal(expectedStream.join(''), writtenString, 'Sent content should be eqaul to expected content');
 
       test.done();
   }


### PR DESCRIPTION
ActiveMQ(and in some cases RabbitMQ) will fail if TextMessage has content-length header.
When we send frame with string in a body we can omit content-length header automatically. 
Package tests are up to date.