### PR TITLE
Fix incorrect encoding of binary data.

### DIFF
--- a/lib/frame.js
+++ b/lib/frame.js
@@ -29,12 +29,11 @@ StompFrame.prototype.send = function(stream) {
     }
   }
   frame += '\n';
+  stream.write(frame);
   if (this.body.length > 0) {
-    frame += this.body;
+    stream.write(this.body);
   }
-  frame += '\0';
-  if(frame)
-    stream.write(frame);
+  stream.write('\0');
 };
 
 StompFrame.prototype.setCommand = function(command) {


### PR DESCRIPTION
This fix allows to send binary data over STOMP.

When sending binary data...converting it from buffer to string could mangle it.
Some example code below to demonstrate the problem.
Note that when converting `myBuffer` to a string, it defaults to Unicode Codepoint 65533 - which is the question mark character - I think that's what node does by default when it tries to convert invalid UTF-8 binary data.

```javascript
const myBuffer = Buffer.from([0xFB]);  // This is not a valid UTF-8 encoding, and so gets mangled when converting from a buffer (assumed to be valid UTF-8) to a string...

const str = myBuffer.toString();
console.log("STR Code Point: " + str.codePointAt(0));
const newBuffer = Buffer.from(str, "utf8");

console.log("myBuffer len: " + myBuffer.length);
console.log("newBuffer len: " + newBuffer.length);
for (let i = 0; i < newBuffer.length; i++) {
  if (i < myBuffer.length) {
    console.log("A: " + myBuffer[i]);
  }
  console.log("B: " + newBuffer[i]);
}
```